### PR TITLE
[PSV-42] fix sword missing from player and add weapon tag to sword

### DIFF
--- a/scenes/player.tscn
+++ b/scenes/player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=3 uid="uid://6aw2iknw3gux"]
+[gd_scene load_steps=15 format=3 uid="uid://6aw2iknw3gux"]
 
 [ext_resource type="Script" path="res://scripts/player.gd" id="1_l1yk1"]
 [ext_resource type="Resource" uid="uid://c2ghf4uta802a" path="res://resources/entity/player.tres" id="2_qj0p0"]
@@ -6,6 +6,7 @@
 [ext_resource type="Texture2D" uid="uid://bmqmoixufgv1m" path="res://assets/hooded_protagonist/character_sprite.png" id="4_plceh"]
 [ext_resource type="PackedScene" uid="uid://dvkfa15qiwcra" path="res://scenes/player/player_movement_component.tscn" id="5_hm3sn"]
 [ext_resource type="PackedScene" uid="uid://wuepqnu7tptu" path="res://scenes/player/player_look_at_component.tscn" id="6_l8n6l"]
+[ext_resource type="PackedScene" uid="uid://cp4h3qqjkkkjs" path="res://weapons/Sword/sword.tscn" id="7_j5af7"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_m5hxm"]
 shader = ExtResource("3_1qxah")
@@ -220,3 +221,5 @@ _animation_player = NodePath("../AnimationPlayer")
 
 [node name="PlayerLookAtComponent" parent="." node_paths=PackedStringArray("_sprite") instance=ExtResource("6_l8n6l")]
 _sprite = NodePath("../Sprite2D")
+
+[node name="WeaponSwordComponent" parent="." instance=ExtResource("7_j5af7")]

--- a/weapons/Sword/sword.tscn
+++ b/weapons/Sword/sword.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" path="res://weapons/Sword/sword.gd" id="1_uf0qa"]
 
-[node name="WeaponSwordComponent" type="Area2D"]
+[node name="WeaponSwordComponent" type="Area2D" groups=["weapons"]]
 collision_mask = 4
 script = ExtResource("1_uf0qa")
 


### PR DESCRIPTION
**Ticket** :
- [PSV-42](https://trello.com/c/3BKfQ2W1/42-separate-weapon-into-its-own-component)

**Changes** :
- `fix` fix sword component missing because not instantiated as player child
- `feat` add weapon tag to sword component