### PR TITLE
Overhaul Player Scene to mostly follow composition rule

### DIFF
--- a/resources/enemies/bat.tres
+++ b/resources/enemies/bat.tres
@@ -7,8 +7,8 @@
 script = ExtResource("1_hw5v1")
 name = "Bat"
 sprite = ExtResource("2_2knja")
-max_health = 10
-health = 10
+max_health = 1
+health = 1
 attack_damage = 1
 move_speed = 50
 attack_cooldown = 2

--- a/resources/enemies/slime.tres
+++ b/resources/enemies/slime.tres
@@ -7,8 +7,8 @@
 script = ExtResource("1_f641i")
 name = "Slime"
 sprite = ExtResource("2_auapi")
-max_health = 10
-health = 10
+max_health = 1
+health = 1
 attack_damage = 1
 move_speed = 50
 attack_cooldown = 2

--- a/resources/entity/player.tres
+++ b/resources/entity/player.tres
@@ -6,7 +6,7 @@
 script = ExtResource("1_ooqcj")
 max_health = 100
 health = 100
-attack_damage = 10
+attack_damage = 1
 move_speed = 100
 attack_cooldown = 1
 level = 1

--- a/scenes/collect_drops_component.tscn
+++ b/scenes/collect_drops_component.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://dagmveyrwqto1"]
+
+[ext_resource type="Script" path="res://scripts/collect_drops_component.gd" id="1_khj7m"]
+
+[node name="CollectDropsComponent" type="Area2D"]
+script = ExtResource("1_khj7m")

--- a/scenes/player.tscn
+++ b/scenes/player.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=13 format=3 uid="uid://6aw2iknw3gux"]
+[gd_scene load_steps=14 format=3 uid="uid://6aw2iknw3gux"]
 
 [ext_resource type="Script" path="res://scripts/player.gd" id="1_l1yk1"]
 [ext_resource type="Resource" uid="uid://c2ghf4uta802a" path="res://resources/entity/player.tres" id="2_qj0p0"]
 [ext_resource type="Shader" path="res://shaders/player.gdshader" id="3_1qxah"]
 [ext_resource type="Texture2D" uid="uid://bmqmoixufgv1m" path="res://assets/hooded_protagonist/character_sprite.png" id="4_plceh"]
 [ext_resource type="PackedScene" uid="uid://dvkfa15qiwcra" path="res://scenes/player/player_movement_component.tscn" id="5_hm3sn"]
+[ext_resource type="PackedScene" uid="uid://wuepqnu7tptu" path="res://scenes/player/player_look_at_component.tscn" id="6_l8n6l"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_m5hxm"]
 shader = ExtResource("3_1qxah")
@@ -181,10 +182,11 @@ _data = {
 "walking": SubResource("Animation_wflf6")
 }
 
-[node name="Player" type="CharacterBody2D" groups=["player"]]
+[node name="Player" type="CharacterBody2D" node_paths=PackedStringArray("_player_look_at_comp") groups=["player"]]
 collision_layer = 14
 script = ExtResource("1_l1yk1")
 _resource = ExtResource("2_qj0p0")
+_player_look_at_comp = NodePath("PlayerLookAtComponent")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 material = SubResource("ShaderMaterial_m5hxm")
@@ -230,5 +232,8 @@ libraries = {
 [node name="PlayerMovementComponent" parent="." node_paths=PackedStringArray("_body", "_animation_player") instance=ExtResource("5_hm3sn")]
 _body = NodePath("..")
 _animation_player = NodePath("../AnimationPlayer")
+
+[node name="PlayerLookAtComponent" parent="." node_paths=PackedStringArray("_sprite") instance=ExtResource("6_l8n6l")]
+_sprite = NodePath("../Sprite2D")
 
 [connection signal="timeout" from="AttackTimer" to="." method="_on_attack_timer_timeout"]

--- a/scenes/player.tscn
+++ b/scenes/player.tscn
@@ -231,6 +231,4 @@ libraries = {
 _body = NodePath("..")
 _animation_player = NodePath("../AnimationPlayer")
 
-[node name="PlayerLookAtComponent" type="Node2D" parent="."]
-
 [connection signal="timeout" from="AttackTimer" to="." method="_on_attack_timer_timeout"]

--- a/scenes/player.tscn
+++ b/scenes/player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=3 uid="uid://6aw2iknw3gux"]
+[gd_scene load_steps=16 format=3 uid="uid://6aw2iknw3gux"]
 
 [ext_resource type="Script" path="res://scripts/player.gd" id="1_l1yk1"]
 [ext_resource type="Resource" uid="uid://c2ghf4uta802a" path="res://resources/entity/player.tres" id="2_qj0p0"]
@@ -7,6 +7,7 @@
 [ext_resource type="PackedScene" uid="uid://dvkfa15qiwcra" path="res://scenes/player/player_movement_component.tscn" id="5_hm3sn"]
 [ext_resource type="PackedScene" uid="uid://wuepqnu7tptu" path="res://scenes/player/player_look_at_component.tscn" id="6_l8n6l"]
 [ext_resource type="PackedScene" uid="uid://cp4h3qqjkkkjs" path="res://weapons/Sword/sword.tscn" id="7_j5af7"]
+[ext_resource type="PackedScene" uid="uid://dagmveyrwqto1" path="res://scenes/collect_drops_component.tscn" id="8_hylks"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_m5hxm"]
 shader = ExtResource("3_1qxah")
@@ -14,9 +15,6 @@ shader_parameter/is_damage_taken = false
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_pefr1"]
 size = Vector2(16, 8.25)
-
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_mhitv"]
-size = Vector2(16, 28)
 
 [sub_resource type="Animation" id="Animation_5o7e5"]
 length = 0.001
@@ -183,6 +181,9 @@ _data = {
 "walking": SubResource("Animation_wflf6")
 }
 
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_7nacx"]
+size = Vector2(16, 28)
+
 [node name="Player" type="CharacterBody2D" groups=["player"]]
 collision_layer = 14
 script = ExtResource("1_l1yk1")
@@ -198,14 +199,6 @@ vframes = 9
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 position = Vector2(-1, 11.875)
 shape = SubResource("RectangleShape2D_pefr1")
-
-[node name="BodyArea" type="Area2D" parent="."]
-position = Vector2(0, 8)
-collision_mask = 8
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="BodyArea"]
-position = Vector2(-1, -8)
-shape = SubResource("RectangleShape2D_mhitv")
 
 [node name="PlayerCamera2D" type="Camera2D" parent="."]
 
@@ -223,3 +216,12 @@ _animation_player = NodePath("../AnimationPlayer")
 _sprite = NodePath("../Sprite2D")
 
 [node name="WeaponSwordComponent" parent="." instance=ExtResource("7_j5af7")]
+
+[node name="CollectDropsComponent" parent="." instance=ExtResource("8_hylks")]
+collision_mask = 8
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="CollectDropsComponent"]
+position = Vector2(-1, 0)
+shape = SubResource("RectangleShape2D_7nacx")
+
+[connection signal="trigger_drop_effect" from="CollectDropsComponent" to="." method="_on_collect_drops_component_trigger_drop_effect"]

--- a/scenes/player.tscn
+++ b/scenes/player.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="Resource" uid="uid://c2ghf4uta802a" path="res://resources/entity/player.tres" id="2_qj0p0"]
 [ext_resource type="Shader" path="res://shaders/player.gdshader" id="3_1qxah"]
 [ext_resource type="Texture2D" uid="uid://bmqmoixufgv1m" path="res://assets/hooded_protagonist/character_sprite.png" id="4_plceh"]
-[ext_resource type="Script" path="res://scripts/player/player_movement_component.gd" id="5_q1hsw"]
+[ext_resource type="PackedScene" uid="uid://dvkfa15qiwcra" path="res://scenes/player/player_movement_component.tscn" id="5_hm3sn"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_m5hxm"]
 shader = ExtResource("3_1qxah")
@@ -227,10 +227,8 @@ libraries = {
 "": SubResource("AnimationLibrary_100jl")
 }
 
-[node name="PlayerMovementComponent" type="Node2D" parent="." node_paths=PackedStringArray("_body", "_animation_player")]
-script = ExtResource("5_q1hsw")
-_resource = ExtResource("2_qj0p0")
-_body = NodePath("..")
-_animation_player = NodePath("../AnimationPlayer")
+[node name="PlayerMovementComponent" parent="." instance=ExtResource("5_hm3sn")]
+
+[node name="PlayerLookAtComponent" type="Node2D" parent="."]
 
 [connection signal="timeout" from="AttackTimer" to="." method="_on_attack_timer_timeout"]

--- a/scenes/player.tscn
+++ b/scenes/player.tscn
@@ -182,44 +182,29 @@ _data = {
 "walking": SubResource("Animation_wflf6")
 }
 
-[node name="Player" type="CharacterBody2D" node_paths=PackedStringArray("_player_look_at_comp") groups=["player"]]
+[node name="Player" type="CharacterBody2D" groups=["player"]]
 collision_layer = 14
 script = ExtResource("1_l1yk1")
 _resource = ExtResource("2_qj0p0")
-_player_look_at_comp = NodePath("PlayerLookAtComponent")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 material = SubResource("ShaderMaterial_m5hxm")
-position = Vector2(0, -10)
+position = Vector2(0, -2)
 texture = ExtResource("4_plceh")
 hframes = 8
 vframes = 9
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-position = Vector2(-1, 3.875)
+position = Vector2(-1, 11.875)
 shape = SubResource("RectangleShape2D_pefr1")
 
-[node name="Weapon" type="Area2D" parent="."]
-position = Vector2(0, -10)
-collision_mask = 4
-
-[node name="Sword" type="Line2D" parent="Weapon"]
-position = Vector2(0, 5)
-points = PackedVector2Array(0, 0, 50, 0)
-width = 1.0
-
-[node name="AttackCollisionShape" type="CollisionPolygon2D" parent="Weapon"]
-position = Vector2(0, 5)
-polygon = PackedVector2Array(25, -43, 32, -38, 38, -32, 43, -25, 47, -17, 49, -9, 50, 0, 49, 9, 47, 17, 43, 25, 38, 32, 32, 38, 25, 43, 0, 0)
-
 [node name="BodyArea" type="Area2D" parent="."]
+position = Vector2(0, 8)
 collision_mask = 8
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="BodyArea"]
 position = Vector2(-1, -8)
 shape = SubResource("RectangleShape2D_mhitv")
-
-[node name="AttackTimer" type="Timer" parent="."]
 
 [node name="PlayerCamera2D" type="Camera2D" parent="."]
 
@@ -235,5 +220,3 @@ _animation_player = NodePath("../AnimationPlayer")
 
 [node name="PlayerLookAtComponent" parent="." node_paths=PackedStringArray("_sprite") instance=ExtResource("6_l8n6l")]
 _sprite = NodePath("../Sprite2D")
-
-[connection signal="timeout" from="AttackTimer" to="." method="_on_attack_timer_timeout"]

--- a/scenes/player.tscn
+++ b/scenes/player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=3 uid="uid://6aw2iknw3gux"]
+[gd_scene load_steps=15 format=3 uid="uid://6aw2iknw3gux"]
 
 [ext_resource type="Script" path="res://scripts/player.gd" id="1_l1yk1"]
 [ext_resource type="Resource" uid="uid://c2ghf4uta802a" path="res://resources/entity/player.tres" id="2_qj0p0"]
@@ -6,6 +6,7 @@
 [ext_resource type="Texture2D" uid="uid://bmqmoixufgv1m" path="res://assets/hooded_protagonist/character_sprite.png" id="4_plceh"]
 [ext_resource type="PackedScene" uid="uid://dvkfa15qiwcra" path="res://scenes/player/player_movement_component.tscn" id="5_hm3sn"]
 [ext_resource type="PackedScene" uid="uid://wuepqnu7tptu" path="res://scenes/player/player_look_at_component.tscn" id="6_l8n6l"]
+[ext_resource type="PackedScene" uid="uid://cp4h3qqjkkkjs" path="res://weapons/Sword/sword.tscn" id="7_j5af7"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_m5hxm"]
 shader = ExtResource("3_1qxah")
@@ -220,3 +221,5 @@ _animation_player = NodePath("../AnimationPlayer")
 
 [node name="PlayerLookAtComponent" parent="." node_paths=PackedStringArray("_sprite") instance=ExtResource("6_l8n6l")]
 _sprite = NodePath("../Sprite2D")
+
+[node name="WeaponSwordComponent" parent="." instance=ExtResource("7_j5af7")]

--- a/scenes/player.tscn
+++ b/scenes/player.tscn
@@ -227,7 +227,9 @@ libraries = {
 "": SubResource("AnimationLibrary_100jl")
 }
 
-[node name="PlayerMovementComponent" parent="." instance=ExtResource("5_hm3sn")]
+[node name="PlayerMovementComponent" parent="." node_paths=PackedStringArray("_body", "_animation_player") instance=ExtResource("5_hm3sn")]
+_body = NodePath("..")
+_animation_player = NodePath("../AnimationPlayer")
 
 [node name="PlayerLookAtComponent" type="Node2D" parent="."]
 

--- a/scenes/player.tscn
+++ b/scenes/player.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=12 format=3 uid="uid://6aw2iknw3gux"]
+[gd_scene load_steps=13 format=3 uid="uid://6aw2iknw3gux"]
 
 [ext_resource type="Script" path="res://scripts/player.gd" id="1_l1yk1"]
 [ext_resource type="Resource" uid="uid://c2ghf4uta802a" path="res://resources/entity/player.tres" id="2_qj0p0"]
 [ext_resource type="Shader" path="res://shaders/player.gdshader" id="3_1qxah"]
 [ext_resource type="Texture2D" uid="uid://bmqmoixufgv1m" path="res://assets/hooded_protagonist/character_sprite.png" id="4_plceh"]
+[ext_resource type="Script" path="res://scripts/player/player_movement_component.gd" id="5_q1hsw"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_m5hxm"]
 shader = ExtResource("3_1qxah")
@@ -225,5 +226,11 @@ autoplay = "idle"
 libraries = {
 "": SubResource("AnimationLibrary_100jl")
 }
+
+[node name="PlayerMovementComponent" type="Node2D" parent="." node_paths=PackedStringArray("_body", "_animation_player")]
+script = ExtResource("5_q1hsw")
+_resource = ExtResource("2_qj0p0")
+_body = NodePath("..")
+_animation_player = NodePath("../AnimationPlayer")
 
 [connection signal="timeout" from="AttackTimer" to="." method="_on_attack_timer_timeout"]

--- a/scenes/player/player_look_at_component.tscn
+++ b/scenes/player/player_look_at_component.tscn
@@ -1,0 +1,7 @@
+[gd_scene load_steps=2 format=3 uid="uid://wuepqnu7tptu"]
+
+[ext_resource type="Script" path="res://scripts/player/player_look_at_component.gd" id="1_mw4cq"]
+
+[node name="PlayerLookAtComponent" type="Node2D" node_paths=PackedStringArray("_sprite")]
+script = ExtResource("1_mw4cq")
+_sprite = NodePath("")

--- a/scenes/player/player_movement_component.tscn
+++ b/scenes/player/player_movement_component.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=3 format=3 uid="uid://dvkfa15qiwcra"]
+
+[ext_resource type="Script" path="res://scripts/player/player_movement_component.gd" id="1_x4ju7"]
+[ext_resource type="Resource" uid="uid://c2ghf4uta802a" path="res://resources/entity/player.tres" id="2_7wthu"]
+
+[node name="PlayerMovementComponent" type="Node2D" node_paths=PackedStringArray("_body", "_animation_player")]
+script = ExtResource("1_x4ju7")
+_resource = ExtResource("2_7wthu")
+_body = NodePath("")
+_animation_player = NodePath("")

--- a/scripts/collect_drops_component.gd
+++ b/scripts/collect_drops_component.gd
@@ -1,0 +1,16 @@
+extends Area2D
+class_name CollectDropsComponent
+
+
+signal trigger_drop_effect(drop: Area2D)
+
+
+func _process(_delta) -> void:
+	_collect_drops()
+
+
+func _collect_drops() -> void:
+	for area in get_overlapping_areas():
+		if area.is_in_group("drops"):
+			trigger_drop_effect.emit(area)
+			area.destroy()

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -3,6 +3,7 @@ extends CharacterBody2D
 
 @export var _resource: Resource_Player
 @export var _damage_shader_delay: float = 0.1
+@export var _player_look_at_comp: PlayerLookAtComponent
 
 @onready var _game_camera_node: Camera2D = get_node("../GameCamera2D")
 
@@ -20,20 +21,9 @@ func _start():
 
 
 func _physics_process(_delta):
-	var input = Input.get_vector("left", "right", "top", "down")
-	_handle_character_facing(_get_mouse_lookat_vector())
-	_handle_attack(_get_mouse_lookat_vector())
+	_handle_attack(_player_look_at_comp.get_look_at())
 	_handle_destory()
 	_collect_drops()
-
-
-func _handle_character_facing(input):
-	# handle horizontal facing
-	if input.x > 0:
-		get_node("Sprite2D").set_flip_h(false)
-		
-	elif input.x < 0:
-		get_node("Sprite2D").set_flip_h(true)
 
 
 func _handle_weapon_facing(look_at_vec):
@@ -69,12 +59,6 @@ func _collect_drops():
 		if area.is_in_group("drops"):
 			_resource.update_level(area.exp_point)
 			area.destroy()
-
-
-func _get_mouse_lookat_vector():
-	var center_viewport_position = get_viewport_rect().size / 2
-	var mouse_position = get_viewport().get_mouse_position()
-	return (mouse_position - center_viewport_position).normalized()
 
 
 func deal_damage(damage_amount: int):

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -21,23 +21,10 @@ func _start():
 
 func _physics_process(_delta):
 	var input = Input.get_vector("left", "right", "top", "down")
-	_handle_movement(input)
 	_handle_character_facing(_get_mouse_lookat_vector())
 	_handle_attack(_get_mouse_lookat_vector())
 	_handle_destory()
 	_collect_drops()
-
-
-func _handle_movement(input):
-	# animation
-	if input != Vector2.ZERO:
-		$AnimationPlayer.play("walking")
-	else:
-		$AnimationPlayer.play("idle")
-	
-	# logic
-	velocity = _resource.move_speed * input
-	move_and_slide()
 
 
 func _handle_character_facing(input):

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -3,11 +3,8 @@ extends CharacterBody2D
 
 @export var _resource: Resource_Player
 @export var _damage_shader_delay: float = 0.1
-@export var _player_look_at_comp: PlayerLookAtComponent
 
 @onready var _game_camera_node: Camera2D = get_node("../GameCamera2D")
-
-var _can_attack: bool = true
 
 
 func _ready():
@@ -16,35 +13,12 @@ func _ready():
 
 func _start():
 	$PlayerCamera2D.make_current()
-	$AttackTimer.wait_time = _resource.attack_cooldown
 	_resource.setup_level()
 
 
 func _physics_process(_delta):
-	_handle_attack(_player_look_at_comp.get_look_at())
 	_handle_destory()
 	_collect_drops()
-
-
-func _handle_weapon_facing(look_at_vec):
-	$Weapon/Sword.rotation = look_at_vec.angle()
-	$Weapon/AttackCollisionShape.rotation = look_at_vec.angle()
-
-
-func _handle_attack(look_at_vec):
-	# handle where to attack
-	_handle_weapon_facing(look_at_vec)
-	
-	# check if possible to attack
-	if not _can_attack:
-		return
-	_can_attack = false
-	$AttackTimer.start()
-	
-	# handle deal damage to all enemy inside the hitbox
-	for area in $Weapon.get_overlapping_areas():
-		if area.is_in_group("enemies"):
-			area.deal_damage(_resource.attack_damage)
 
 
 func _handle_destory():
@@ -66,7 +40,3 @@ func deal_damage(damage_amount: int):
 	_resource.health -= damage_amount
 	await get_tree().create_timer(_damage_shader_delay).timeout
 	$Sprite2D.material.set_shader_parameter("is_damage_taken", false)
-
-
-func _on_attack_timer_timeout():
-	_can_attack = true

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -18,7 +18,6 @@ func _start():
 
 func _physics_process(_delta):
 	_handle_destory()
-	_collect_drops()
 
 
 func _handle_destory():
@@ -28,15 +27,12 @@ func _handle_destory():
 		queue_free()
 
 
-func _collect_drops():
-	for area in $BodyArea.get_overlapping_areas():
-		if area.is_in_group("drops"):
-			_resource.update_level(area.exp_point)
-			area.destroy()
-
-
 func deal_damage(damage_amount: int):
 	$Sprite2D.material.set_shader_parameter("is_damage_taken", true)
 	_resource.health -= damage_amount
 	await get_tree().create_timer(_damage_shader_delay).timeout
 	$Sprite2D.material.set_shader_parameter("is_damage_taken", false)
+
+
+func _on_collect_drops_component_trigger_drop_effect(drop) -> void:
+	_resource.update_level(drop.exp_point)

--- a/scripts/player/player_look_at_component.gd
+++ b/scripts/player/player_look_at_component.gd
@@ -1,0 +1,34 @@
+extends Node2D
+class_name PlayerLookAtComponent
+
+
+@export var _sprite: Sprite2D
+var _look_at: Vector2: set = _set_look_at, get = get_look_at
+
+
+func _set_look_at(value: Vector2):
+	_look_at = value
+
+
+func get_look_at() -> Vector2:
+	return _look_at
+
+
+func _process(_delta) -> void:
+	var input = Input.get_vector("left", "right", "top", "down")
+	_handle_sprite_facing(input)
+	_set_look_at(_get_mouse_lookat_vector())
+
+
+func _handle_sprite_facing(input: Vector2) -> void:
+	if input.x > 0:
+		_sprite.set_flip_h(false)
+		
+	elif input.x < 0:
+		_sprite.set_flip_h(true)
+
+
+func _get_mouse_lookat_vector() -> Vector2:
+	var center_viewport_position = get_viewport_rect().size / 2
+	var mouse_position = get_viewport().get_mouse_position()
+	return (mouse_position - center_viewport_position).normalized()

--- a/scripts/player/player_movement_component.gd
+++ b/scripts/player/player_movement_component.gd
@@ -1,0 +1,24 @@
+extends Node2D
+
+
+@export var _resource: Resource_Player
+@export var _body: CharacterBody2D
+@export var _animation_player: AnimationPlayer
+
+
+func _physics_process(_delta):
+	var input = Input.get_vector("left", "right", "top", "down")
+	_handle_movement(input)
+	_handle_animation(input)
+
+
+func _handle_movement(input: Vector2):
+	_body.velocity = _resource.move_speed * input
+	_body.move_and_slide()
+
+
+func _handle_animation(input: Vector2):
+	if input != Vector2.ZERO:
+		_animation_player.play("walking")
+	else:
+		_animation_player.play("idle")

--- a/scripts/resources/resource_weapon.gd
+++ b/scripts/resources/resource_weapon.gd
@@ -1,0 +1,6 @@
+extends Resource
+
+class_name Resource_Weapon
+
+@export var attack: int
+@export var attack_cooldown: int

--- a/weapons/Sword/sword.gd
+++ b/weapons/Sword/sword.gd
@@ -1,0 +1,52 @@
+extends Area2D
+class_name WeaponSwordComponent
+
+
+@onready var _player_stats: Resource_Player = preload("res://resources/entity/player.tres")
+@onready var _weapon_stats: Resource_Weapon = preload("res://weapons/Sword/sword.tres")
+
+var _player_look_at_component: PlayerLookAtComponent
+var _look_at_vec: Vector2
+var _can_attack: bool = true
+
+
+func _ready() -> void:
+	$AttackDelayTimer.wait_time = _weapon_stats.attack_cooldown
+	_player_look_at_component = get_node("../PlayerLookAtComponent")
+	_update_player_look_at_vec()
+
+
+func _process(_delta) -> void:
+	_update_player_look_at_vec()
+	_handle_aim()
+	_handle_attack()
+
+
+func _update_player_look_at_vec() -> void:
+	if _player_look_at_component is PlayerLookAtComponent:
+		_look_at_vec = _player_look_at_component.get_look_at()
+
+
+func _handle_aim() -> void:
+	rotation = _look_at_vec.angle()
+
+
+func _handle_attack() -> void:
+	# check if possible to attack
+	if not _can_attack:
+		return
+	_can_attack = false
+	$AttackDelayTimer.start()
+	
+	# handle deal damage to all enemy inside the hitbox
+	for area in get_overlapping_areas():
+		if area.is_in_group("enemies"):
+			area.deal_damage(_calculate_attack_damage())
+
+
+func _calculate_attack_damage() -> int:
+	return _player_stats.attack_damage + _weapon_stats.attack
+
+
+func _on_attack_delay_timer_timeout() -> void:
+	_can_attack = true

--- a/weapons/Sword/sword.tres
+++ b/weapons/Sword/sword.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Resource" script_class="Resource_Weapon" load_steps=2 format=3 uid="uid://cwddl2l32ewlr"]
+
+[ext_resource type="Script" path="res://scripts/resources/resource_weapon.gd" id="1_jefu4"]
+
+[resource]
+script = ExtResource("1_jefu4")
+attack = 1
+attack_cooldown = 1

--- a/weapons/Sword/sword.tscn
+++ b/weapons/Sword/sword.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" path="res://weapons/Sword/sword.gd" id="1_uf0qa"]
 
-[node name="WeaponSwordComponent" type="Area2D"]
+[node name="WeaponSwordComponent" type="Area2D" groups=["weapons"]]
 collision_mask = 4
 script = ExtResource("1_uf0qa")
 

--- a/weapons/Sword/sword.tscn
+++ b/weapons/Sword/sword.tscn
@@ -1,0 +1,18 @@
+[gd_scene load_steps=2 format=3 uid="uid://cp4h3qqjkkkjs"]
+
+[ext_resource type="Script" path="res://weapons/Sword/sword.gd" id="1_uf0qa"]
+
+[node name="WeaponSwordComponent" type="Area2D"]
+collision_mask = 4
+script = ExtResource("1_uf0qa")
+
+[node name="SpriteTemplate" type="Line2D" parent="."]
+points = PackedVector2Array(0, 0, 50, 0)
+width = 1.0
+
+[node name="AttackCollisionShape" type="CollisionPolygon2D" parent="."]
+polygon = PackedVector2Array(25, -43, 32, -38, 38, -32, 43, -25, 47, -17, 49, -9, 50, 0, 49, 9, 47, 17, 43, 25, 38, 32, 32, 38, 25, 43, 0, 0)
+
+[node name="AttackDelayTimer" type="Timer" parent="."]
+
+[connection signal="timeout" from="AttackDelayTimer" to="." method="_on_attack_delay_timer_timeout"]


### PR DESCRIPTION
**Ticket** :
- [PSV-40](https://trello.com/c/lSpJFi4z/40-separate-player-movement-into-its-own-component)
- [PSV-41](https://trello.com/c/Vtywdj7Q/41-separate-player-aim-look-at-into-its-own-component)
- [PSV-42](https://trello.com/c/3BKfQ2W1/42-separate-weapon-into-its-own-component)
- [PSV-43](https://trello.com/c/wAZ0pU0W/43-separate-collect-drops-logic-into-its-own-component)

**Changes** :
- `feat` separate player movement into its own component
- `feat` separate player aim / look at into its own component
- `feat` separate weapon (sword) into its own component
- `feat` separate collect drops into its own component