### PR TITLE
[PS-8] refactor spawn drop logic

### DIFF
--- a/scenes/enemy.tscn
+++ b/scenes/enemy.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=3 uid="uid://cy3yj28aafqjv"]
+[gd_scene load_steps=15 format=3 uid="uid://cy3yj28aafqjv"]
 
 [ext_resource type="Script" path="res://scripts/enemy.gd" id="1_huu1h"]
 [ext_resource type="Shader" path="res://shaders/enemy.gdshader" id="3_6wp2d"]
@@ -8,6 +8,7 @@
 [ext_resource type="PackedScene" uid="uid://bkt335kptwuo5" path="res://scenes/take_damage_component.tscn" id="6_swukt"]
 [ext_resource type="PackedScene" uid="uid://bsdol4wcqsuga" path="res://scenes/auto_move_component.tscn" id="7_y4cxy"]
 [ext_resource type="PackedScene" uid="uid://gdqvm0mxaj2u" path="res://scenes/enemy_attack_component.tscn" id="8_td8j5"]
+[ext_resource type="PackedScene" uid="uid://dxcr48t6qowac" path="res://scenes/spawn_drop_component.tscn" id="9_hjenw"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_r6w4x"]
 resource_local_to_scene = true
@@ -104,15 +105,15 @@ _data = {
 "idle": SubResource("Animation_tqh6n")
 }
 
-[node name="Enemy" type="Area2D" node_paths=PackedStringArray("_destroy_comp", "_take_damage_comp", "_auto_move_comp", "_enemy_attack_comp") groups=["enemies"]]
+[node name="Enemy" type="Area2D" node_paths=PackedStringArray("_destroy_comp", "_take_damage_comp", "_auto_move_comp", "_enemy_attack_comp", "_exp_drop_comp") groups=["enemies"]]
 collision_layer = 4
 collision_mask = 4
 script = ExtResource("1_huu1h")
-_exp_drop_scene = ExtResource("3_t0c5r")
 _destroy_comp = NodePath("DestroyComponent")
 _take_damage_comp = NodePath("TakeDamageComponent")
 _auto_move_comp = NodePath("AutoMoveComponent")
 _enemy_attack_comp = NodePath("EnemyAttackComponent")
+_exp_drop_comp = NodePath("EXPSpawnDropComponent")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 material = SubResource("ShaderMaterial_r6w4x")
@@ -143,4 +144,8 @@ _sprite = NodePath("../Sprite2D")
 [node name="EnemyAttackComponent" parent="." node_paths=PackedStringArray("_enemy_comp") instance=ExtResource("8_td8j5")]
 _enemy_comp = NodePath("..")
 
+[node name="EXPSpawnDropComponent" parent="." instance=ExtResource("9_hjenw")]
+_drop_scene = ExtResource("3_t0c5r")
+
 [connection signal="trigger_side_effect" from="DestroyComponent" to="." method="_on_destroy_component_trigger_side_effect"]
+[connection signal="trigger_additional_config" from="EXPSpawnDropComponent" to="." method="_on_spawn_drop_component_trigger_additional_config"]

--- a/scenes/spawn_drop_component.tscn
+++ b/scenes/spawn_drop_component.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://dxcr48t6qowac"]
+
+[ext_resource type="Script" path="res://scripts/spawn_drop_component.gd" id="1_jan2g"]
+
+[node name="SpawnDropComponent" type="Node2D"]
+script = ExtResource("1_jan2g")

--- a/scripts/enemy.gd
+++ b/scripts/enemy.gd
@@ -2,11 +2,11 @@ extends Area2D
 
 
 @export var _resource: Resource_Enemy: set = set_resource
-@export var _exp_drop_scene: PackedScene
 @export var _destroy_comp: DestroyComponent
 @export var _take_damage_comp: TakeDamageComponent
 @export var _auto_move_comp: AutoMoveComponent
 @export var _enemy_attack_comp: EnemyAttackComponent
+@export var _exp_drop_comp: SpawnDropComponent
 
 @onready var _player = get_node("../../Player")
 @onready var _drops_container = get_node("../../DropsContainer")
@@ -21,6 +21,7 @@ func set_resource(value: Resource_Enemy):
 func _ready() -> void:
 	$Sprite2D.texture = _resource.sprite
 	_enemy_attack_comp.set_player_comp(_player)
+	_exp_drop_comp.set_drop_container(_drops_container)
 
 
 func _process(delta):
@@ -30,16 +31,13 @@ func _process(delta):
 	_auto_move_comp.move_towards_position(_player.position, _resource.move_speed, delta)
 
 
-func _spawn_exp_drop():
-	var e = _exp_drop_scene.instantiate()
-	e.position = position
-	e.exp_point = _resource.exp_point
-	_drops_container.add_child(e)
-
-
 func take_damage(damage_taken: int) -> void:
 	_take_damage_comp.take_damage(damage_taken)
 
 
 func _on_destroy_component_trigger_side_effect() -> void:
-	_spawn_exp_drop()
+	_exp_drop_comp.spawn()
+
+
+func _on_spawn_drop_component_trigger_additional_config(drop_scene) -> void:
+	drop_scene.exp_point = _resource.exp_point

--- a/scripts/spawn_drop_component.gd
+++ b/scripts/spawn_drop_component.gd
@@ -1,0 +1,23 @@
+extends Node2D
+class_name SpawnDropComponent
+
+
+signal trigger_additional_config(drop_scene: PackedScene)
+
+@export var _drop_scene: PackedScene: set = set_drop_scene
+@export var _drop_container: Node2D: set = set_drop_container
+
+
+func set_drop_scene(scene: PackedScene) -> void:
+	_drop_scene = scene
+
+
+func set_drop_container(node: Node2D) -> void:
+	_drop_container = node
+
+
+func spawn() -> void:
+	var drop = _drop_scene.instantiate()
+	drop.position = get_parent().position
+	trigger_additional_config.emit(drop)
+	_drop_container.add_child(drop)


### PR DESCRIPTION
**Ticket** :
- https://reyhanfarabi.atlassian.net/browse/PS-8

**Changes** :
- `feat` separate spawn drop into its own component called SpawnDropComponent
- `feat` reintegrate exp spawn drop when enemy died using SpawnDropComponent to EnemyComponent