### PR TITLE
[PS-29] add logic to main menu screen

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="Project Survive"
-run/main_scene="res://scenes/game.tscn"
+run/main_scene="res://scenes/main_menu_screen_component.tscn"
 config/features=PackedStringArray("4.1", "Forward Plus")
 config/icon="res://icon.svg"
 
@@ -21,6 +21,13 @@ window/stretch/mode="canvas_items"
 
 [input]
 
+ui_accept={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194309,"physical_keycode":0,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194310,"physical_keycode":0,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":0,"pressure":0.0,"pressed":false,"script":null)
+]
+}
 left={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":97,"echo":false,"script":null)

--- a/scenes/main_menu_screen_component.tscn
+++ b/scenes/main_menu_screen_component.tscn
@@ -1,6 +1,9 @@
-[gd_scene format=3 uid="uid://bqr4cphhkgyoi"]
+[gd_scene load_steps=2 format=3 uid="uid://bqr4cphhkgyoi"]
+
+[ext_resource type="Script" path="res://scripts/main_menu_screen_component.gd" id="1_agfp6"]
 
 [node name="MainMenuScreenComponent" type="CanvasLayer"]
+script = ExtResource("1_agfp6")
 
 [node name="Control" type="Control" parent="."]
 layout_mode = 3
@@ -22,15 +25,15 @@ offset_bottom = 444.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Control/VBoxContainer"]
+[node name="TitleContainer" type="VBoxContainer" parent="Control/VBoxContainer"]
 layout_mode = 2
 
-[node name="GameTitle" type="Label" parent="Control/VBoxContainer/VBoxContainer"]
+[node name="GameTitle" type="Label" parent="Control/VBoxContainer/TitleContainer"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
 text = "Project Survive"
 
-[node name="GameAuthor" type="Label" parent="Control/VBoxContainer/VBoxContainer"]
+[node name="GameAuthor" type="Label" parent="Control/VBoxContainer/TitleContainer"]
 layout_mode = 2
 size_flags_horizontal = 8
 text = "by FReyM
@@ -40,14 +43,14 @@ text = "by FReyM
 layout_mode = 2
 theme_override_constants/margin_top = 128
 
-[node name="VBoxContainer2" type="VBoxContainer" parent="Control/VBoxContainer"]
+[node name="MenuButtonContainer" type="VBoxContainer" parent="Control/VBoxContainer"]
 layout_mode = 2
 
-[node name="StartGameButton" type="Button" parent="Control/VBoxContainer/VBoxContainer2"]
+[node name="StartGameButton" type="Button" parent="Control/VBoxContainer/MenuButtonContainer"]
 layout_mode = 2
 text = "Start Game"
 
-[node name="QuitButton" type="Button" parent="Control/VBoxContainer/VBoxContainer2"]
+[node name="QuitButton" type="Button" parent="Control/VBoxContainer/MenuButtonContainer"]
 layout_mode = 2
 text = "Quit"
 
@@ -61,3 +64,6 @@ offset_right = 59.0
 offset_bottom = 608.0
 grow_vertical = 0
 text = "v0.3.0.1"
+
+[connection signal="pressed" from="Control/VBoxContainer/MenuButtonContainer/StartGameButton" to="." method="_on_start_game_button_pressed"]
+[connection signal="pressed" from="Control/VBoxContainer/MenuButtonContainer/QuitButton" to="." method="_on_quit_button_pressed"]

--- a/scripts/main_menu_screen_component.gd
+++ b/scripts/main_menu_screen_component.gd
@@ -1,0 +1,30 @@
+extends CanvasLayer
+
+
+@onready var _start_game_button: Button = $Control/VBoxContainer/MenuButtonContainer/StartGameButton
+@onready var _version_number_label: Label = $Control/VersionNumberLabel
+
+
+func _ready() -> void:
+	_start_game_button.grab_focus()
+	_set_project_version()
+
+
+func _set_project_version() -> void:
+	print(_get_project_version())
+	_version_number_label.text = "v" + _get_project_version()
+
+
+func _get_project_version() -> String:
+	var export_config = ConfigFile.new()
+	var export_config_path = "res://export_presets.cfg"
+	var config_error = export_config.load(export_config_path)
+	return export_config.get_value("preset.0.options", "application/product_version", "dynamic product version")
+
+
+func _on_start_game_button_pressed() -> void:
+	get_tree().change_scene_to_file("res://scenes/game.tscn")
+	
+
+func _on_quit_button_pressed() -> void:
+	get_tree().quit()


### PR DESCRIPTION
**Ticket** :
- https://reyhanfarabi.atlassian.net/browse/PS-29

**Changes** :
- `feat` set main menu screen as start screen
- `feat` add logic to navigate main menu button
- `feat` add logic to start game button
- `feat` add logic to quit button
- `feat` add logic to set version number
- `feat` add joypad button 0 to input map
