### PR TITLE
[PS-34] add logic to game over screen and minor adjustment

### DIFF
--- a/scenes/game.tscn
+++ b/scenes/game.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=13 format=3 uid="uid://bce56et1xspna"]
+[gd_scene load_steps=14 format=3 uid="uid://bce56et1xspna"]
 
 [ext_resource type="Texture2D" uid="uid://b1k56huheu54c" path="res://assets/texture/TX Tileset Grass.png" id="1_3sk7a"]
 [ext_resource type="Texture2D" uid="uid://hcmvhwscuw01" path="res://assets/texture/TX Tileset Wall.png" id="2_3iqga"]
@@ -8,6 +8,7 @@
 [ext_resource type="PackedScene" uid="uid://dfwwktobs2ab7" path="res://scenes/ui.tscn" id="7_1jlsa"]
 [ext_resource type="PackedScene" uid="uid://bflv2yakif0iw" path="res://scenes/paused_menu_screen_component.tscn" id="8_3qpd7"]
 [ext_resource type="Script" path="res://scripts/enemy_source_spawner.gd" id="8_p0jw0"]
+[ext_resource type="PackedScene" uid="uid://pl2lrypa48t5" path="res://scenes/game_over_screen_component.tscn" id="9_1trj6"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_si7rc"]
 texture = ExtResource("1_3sk7a")
@@ -308,8 +309,9 @@ process_mode = 1
 [node name="GameCamera2D" type="Camera2D" parent="."]
 process_mode = 1
 
-[node name="Player" parent="." instance=ExtResource("3_5vid3")]
+[node name="Player" parent="." node_paths=PackedStringArray("_game_over_screen_comp") instance=ExtResource("3_5vid3")]
 process_mode = 1
+_game_over_screen_comp = NodePath("../GameOverScreenComponent")
 
 [node name="EnemySourceSpawner" type="Node2D" parent="."]
 process_mode = 1
@@ -323,5 +325,8 @@ process_mode = 1
 offset_bottom = 36.0
 size_flags_horizontal = 0
 
-[node name="PausedMenuComponent" parent="." node_paths=PackedStringArray("_ui_layer") instance=ExtResource("8_3qpd7")]
+[node name="PausedMenuComponent" parent="." node_paths=PackedStringArray("_ui_layer", "_player_comp") instance=ExtResource("8_3qpd7")]
 _ui_layer = NodePath("../UILayer")
+_player_comp = NodePath("../Player")
+
+[node name="GameOverScreenComponent" parent="." instance=ExtResource("9_1trj6")]

--- a/scenes/game_over_screen_component.tscn
+++ b/scenes/game_over_screen_component.tscn
@@ -1,6 +1,10 @@
-[gd_scene format=3 uid="uid://pl2lrypa48t5"]
+[gd_scene load_steps=2 format=3 uid="uid://pl2lrypa48t5"]
+
+[ext_resource type="Script" path="res://scripts/game_over_screen_component.gd" id="1_phk0g"]
 
 [node name="GameOverScreenComponent" type="CanvasLayer"]
+visible = false
+script = ExtResource("1_phk0g")
 
 [node name="Control" type="Control" parent="."]
 layout_mode = 3
@@ -58,3 +62,7 @@ text = "Restart Game"
 layout_mode = 2
 text = "Quit to Menu
 "
+
+[connection signal="visibility_changed" from="." to="." method="_on_visibility_changed"]
+[connection signal="pressed" from="Control/VBoxContainer/MenuButtonContainer/RestartGameButton" to="." method="_on_restart_game_button_pressed"]
+[connection signal="pressed" from="Control/VBoxContainer/MenuButtonContainer/QuitToMenuButton" to="." method="_on_quit_to_menu_button_pressed"]

--- a/scripts/game_over_screen_component.gd
+++ b/scripts/game_over_screen_component.gd
@@ -1,0 +1,23 @@
+extends CanvasLayer
+class_name GameOverScreenComponent
+
+
+@onready var _restart_button: Button = $Control/VBoxContainer/MenuButtonContainer/RestartGameButton
+
+
+func _ready():
+	hide()
+
+
+func _on_restart_game_button_pressed() -> void:
+	# add restart logic here
+	pass
+
+
+func _on_quit_to_menu_button_pressed() -> void:
+	get_tree().change_scene_to_file("res://scenes/main_menu_screen_component.tscn")
+
+
+func _on_visibility_changed():
+	if visible:
+		_restart_button.grab_focus()

--- a/scripts/paused_menu_screen_component.gd
+++ b/scripts/paused_menu_screen_component.gd
@@ -5,6 +5,7 @@ class_name PausedMenuScreenComponent
 @onready var _continue_button: Button = $Control/VBoxContainer/MenuButtonContainer/ContinueGameButton
 
 @export var _ui_layer: CanvasLayer
+@export var _player_comp: PlayerComponent
 
 
 func _ready() -> void:
@@ -12,7 +13,7 @@ func _ready() -> void:
 	
 
 func _input(event) -> void:
-	if event.is_action_released("paused"):
+	if is_instance_valid(_player_comp) and event.is_action_released("paused"):
 		visible = !visible
 		_ui_layer.visible = !_ui_layer.visible
 		get_tree().paused = !get_tree().paused

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -5,12 +5,16 @@ class_name PlayerComponent
 @export var _resource: Resource_Player
 @export var _destroy_comp: DestroyComponent
 @export var _take_damage_comp: TakeDamageComponent
+@export var _game_over_screen_comp: GameOverScreenComponent
 
 @onready var _game_camera_node: Camera2D = get_node("../GameCamera2D")
 
 
 func _ready():
 	_start()
+	
+	# temporary code to enable play game again from main menu after died
+	_resource.health = 100
 
 
 func _start():
@@ -35,3 +39,5 @@ func _on_destroy_component_trigger_side_effect() -> void:
 	# change active camera to camera inside Game Node
 	_game_camera_node.position = position
 	_game_camera_node.make_current()
+
+	_game_over_screen_comp.show()


### PR DESCRIPTION
**Ticket** :
- https://reyhanfarabi.atlassian.net/browse/PS-34

**Changes** :
- `feat` add logic to game over screen
- `fix` add temporary fix to enable reset play from main menu after died
- `fix` prevent open pause screen when game over
